### PR TITLE
feat: Support glob pattern in options.project

### DIFF
--- a/.changeset/slow-jobs-confess.md
+++ b/.changeset/slow-jobs-confess.md
@@ -1,0 +1,5 @@
+---
+"typescript-eslint-parser-for-extra-files": minor
+---
+
+feat: Support glob pattern in `options.project`

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "eslint-plugin-svelte": "^2.11.0",
     "eslint-plugin-vue": "^9.6.0",
     "eslint-plugin-yml": "^1.2.0",
+    "glob": "^10.3.10",
     "mocha": "^10.0.0",
     "mocha-chai-jest-snapshot": "^1.1.3",
     "nyc": "^15.1.0",

--- a/src/utils/get-project-config-files.ts
+++ b/src/utils/get-project-config-files.ts
@@ -1,16 +1,26 @@
 import type { ParserOptions } from "@typescript-eslint/parser";
 import fs from "fs";
+import { glob } from "glob";
 import path from "path";
+
+function syncWithGlob(pattern: string, cwd: string): string[] {
+  return glob
+    .sync(pattern, { cwd })
+    .map((filePath) => path.resolve(cwd, filePath));
+}
 
 export function getProjectConfigFiles(options: ParserOptions): string[] {
   const tsconfigRootDir =
     typeof options.tsconfigRootDir === "string"
       ? options.tsconfigRootDir
       : process.cwd();
+
   if (options.project !== true) {
     return Array.isArray(options.project)
-      ? options.project
-      : [options.project!];
+      ? options.project.flatMap((projectPattern: string) =>
+          syncWithGlob(projectPattern, tsconfigRootDir),
+        )
+      : syncWithGlob(options.project!, tsconfigRootDir);
   }
 
   let directory = path.dirname(options.filePath!);


### PR DESCRIPTION
Hello, thank you for maintaining such a great project. 

Currently I use glob patterns in parserOptions in typescript eslint parser cause I'm using monorepo. 
But this project seems it doesn't support glob pattern now.

As a result, I added a glob package and use it in `getProjectConfigFiles`