### PR TITLE
fix: Update module to Node16 for esm

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2015",
     "strict": true,
     "lib": ["es2020", "DOM"],
-    "module": "commonjs",
+    "module": "Node16",
     "moduleResolution": "Node16",
     "declaration": true,
     "noImplicitAny": true,


### PR DESCRIPTION
Hello, I met a eslint error when I set `eslint.config.js` as flat config.
`"module": "commonjs"` makes error when it builds in ESM. 